### PR TITLE
Change to StartTime from LastAccessTime for History_Download

### DIFF
--- a/output/SQLiteHunter.yaml
+++ b/output/SQLiteHunter.yaml
@@ -353,7 +353,7 @@ sources:
       get(item=InterruptReason, field=str(str=interrupt_reason), default="Unknown") AS InterruptReason,
       ReferrerURL, SiteURL, TabURL, TabReferrerURL, DownloadURL, OSPath
     FROM Rows
-    WHERE LastAccessTime > DateAfter AND LastAccessTime < DateBefore
+    WHERE StartTime > DateAfter AND StartTime < DateBefore
       AND (SiteURL, DownloadURL, TabURL, TabReferrerURL, ReferrerURL, DownloadURL) =~ FilterRegex
     
 


### PR DESCRIPTION
Fixes #16 

Had this issue also. Sometimes Chrome doesn't pick up DL execution for some reason and last_access_time is 0. Tested the fix, OP was spot on with suggestion. Seems more robust