### PR TITLE
Fix chromium search glob + add globs for Brave on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,12 @@ on: [pull_request]
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.19
+    - name: Set up Go 1.23
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.23
       id: go
 
     - name: Check out code into the Go module directory

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ Globs:
   LinuxChromeProfiles:
     - /home/*/.config/google-chrome
     - /home/*/.config/chrome-remote-desktop/chrome-profile
-    - /home/*/.config/chromium}
+    - /home/*/.config/chromium
   WindowsChromeProfiles:
     - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome/User Data

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ Globs:
     - /home/*/.config/google-chrome
     - /home/*/.config/chrome-remote-desktop/chrome-profile
     - /home/*/.config/chromium
+    - /home/*/{snap/brave/*/,}.config/BraveSoftware/Brave-Browser
   WindowsChromeProfiles:
     - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome/User Data

--- a/definitions/EdgeBrowser_Autofill.yaml
+++ b/definitions/EdgeBrowser_Autofill.yaml
@@ -19,7 +19,7 @@ Globs:
 Sources:
 - name: CombinedAutofill
   VQL: |
-    SELECT timestamp(epoch=date_last_used) AS DateLastUsed
+    SELECT timestamp(epoch=date_last_used) AS DateLastUsed, *
     FROM Rows
     WHERE DateLastUsed > DateAfter AND DateLastUsed < DateBefore
 


### PR DESCRIPTION
- Add extra '}' has been removed from the Linux Chromium glob
- Add globs for Brave (both snap install and Brave's own installer) profile paths on Linux