### PR TITLE
Fix Firefox Dev Profiles and add Chromium, Edge and Chrome Beta, Canary, Dev macOS and Windows. Spelling Fixes. Allows Repo to be Cloned on Windows

### DIFF
--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -10,6 +10,7 @@ Globs:
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome SxS/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome Beta/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome Dev/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Chromium/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge SxS/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge Beta/User Data

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -8,6 +8,9 @@ Globs:
     - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge SxS/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge Beta/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge Dev/User Data
     - C:\Users\*\AppData\{Roaming,Local}\Opera Software\Opera Stable\
   MacOSChromeProfiles:
     - /Users/*/Library/Application Support/BraveSoftware/Brave*/

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -12,6 +12,9 @@ Globs:
   MacOSChromeProfiles:
     - /Users/*/Library/Application Support/BraveSoftware/Brave*/
     - /Users/*/Library/Application Support/Google/Chrome/
+    - /Users/*/Library/Application Support/Google/Chrome Beta/
+    - /Users/*/Library/Application Support/Google/Chrome Canary/
+    - /Users/*/Library/Application Support/Google/Chrome Dev/
     - /Users/*/Library/Application Support/Microsoft Edge/
     - /Users/*/Library/Application Support/Microsoft Edge Beta/
     - /Users/*/Library/Application Support/Microsoft Edge Canary/

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -13,10 +13,11 @@ Globs:
     - /Users/*/Library/Application Support/BraveSoftware/Brave*/
     - /Users/*/Library/Application Support/Google/Chrome/
     - /Users/*/Library/Application Support/Microsoft Edge/
+    - /Users/*/Library/Application Support/Chromium/
   WindowsFirefoxProfiles:
     - C:\Users\*\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles
   LinuxFirefoxProfiles:
     - /home/*/.mozilla/firefox/*.default*
     - /home/*/snap/firefox/common/.mozilla/firefox/*.default*
   MacOSFirefoxProfiles:
-    - /Users/*/Library/Application Support/Firefox/Profiles/*.default*
+    - /Users/*/Library/Application Support/Firefox/Profiles

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -13,6 +13,9 @@ Globs:
     - /Users/*/Library/Application Support/BraveSoftware/Brave*/
     - /Users/*/Library/Application Support/Google/Chrome/
     - /Users/*/Library/Application Support/Microsoft Edge/
+    - /Users/*/Library/Application Support/Microsoft Edge Beta/
+    - /Users/*/Library/Application Support/Microsoft Edge Canary/
+    - /Users/*/Library/Application Support/Microsoft Edge Dev/
     - /Users/*/Library/Application Support/Chromium/
   WindowsFirefoxProfiles:
     - C:\Users\*\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -7,6 +7,9 @@ Globs:
   WindowsChromeProfiles:
     - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome SxS/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome Beta/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome Dev/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge SxS/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge Beta/User Data

--- a/compile/template.yaml
+++ b/compile/template.yaml
@@ -93,7 +93,7 @@ parameters:
 - name: MatchFilename
   description: |
     If set we use the filename to detect the type of sqlite file.
-    When unset we use heristics (slower)
+    When unset we use heuristics (slower)
   type: bool
   default: Y
 
@@ -116,7 +116,7 @@ parameters:
   default: .
 
 - name: All
-  description: Select all tagrgets
+  description: Select all targets
   type: bool
   default: Y
 

--- a/definitions/Firefox_Bookmarks.yaml
+++ b/definitions/Firefox_Bookmarks.yaml
@@ -17,7 +17,7 @@ FilenameRegex: "places.sqlite"
 Globs:
   - "{{WindowsFirefoxProfiles}}/*/places.sqlite"
   - "{{LinuxFirefoxProfiles}}/places.sqlite"
-  - "{{MacOSFirefoxProfiles}}/places.sqlite"
+  - "{{MacOSFirefoxProfiles}}/*/places.sqlite"
 
 Sources:
 - Preamble: |

--- a/definitions/Firefox_Cookies.yaml
+++ b/definitions/Firefox_Cookies.yaml
@@ -16,7 +16,7 @@ FilenameRegex: "cookies.sqlite"
 Globs:
   - "{{WindowsFirefoxProfiles}}/*/cookies.sqlite"
   - "{{LinuxFirefoxProfiles}}/cookies.sqlite"
-  - "{{MacOSFirefoxProfiles}}/cookies.sqlite"
+  - "{{MacOSFirefoxProfiles}}/*/cookies.sqlite"
 
 Sources:
 - VQL: |

--- a/definitions/Firefox_Downloads.yaml
+++ b/definitions/Firefox_Downloads.yaml
@@ -16,7 +16,7 @@ FilenameRegex: "downloads.sqlite"
 Globs:
   - "{{WindowsFirefoxProfiles}}/*/downloads.sqlite"
   - "{{LinuxFirefoxProfiles}}/downloads.sqlite"
-  - "{{MacOSFirefoxProfiles}}/downloads.sqlite"
+  - "{{MacOSFirefoxProfiles}}/*/downloads.sqlite"
 
 Sources:
 - VQL: |

--- a/definitions/Firefox_Favicons.yaml
+++ b/definitions/Firefox_Favicons.yaml
@@ -16,7 +16,7 @@ FilenameRegex: "favicons.sqlite"
 Globs:
   - "{{WindowsFirefoxProfiles}}/*/favicons.sqlite"
   - "{{LinuxFirefoxProfiles}}/favicons.sqlite"
-  - "{{MacOSFirefoxProfiles}}/favicons.sqlite"
+  - "{{MacOSFirefoxProfiles}}/*/favicons.sqlite"
 
 Sources:
 - VQL: |

--- a/definitions/Firefox_FormHistory.yaml
+++ b/definitions/Firefox_FormHistory.yaml
@@ -17,7 +17,7 @@ FilenameRegex: "formhistory.sqlite"
 Globs:
   - "{{WindowsFirefoxProfiles}}/*/formhistory.sqlite"
   - "{{LinuxFirefoxProfiles}}/formhistory.sqlite"
-  - "{{MacOSFirefoxProfiles}}/formhistory.sqlite"
+  - "{{MacOSFirefoxProfiles}}/*/formhistory.sqlite"
 
 Sources:
 - VQL: |

--- a/docs/content/docs/rules/ *Minibuf-1*
+++ b/docs/content/docs/rules/ *Minibuf-1*
@@ -1,1 +1,0 @@
-Directory ‘/home/mic/projects/registry-hunter/docs/content/rules/’ does not exist; create? (y or n) 

--- a/docs/content/docs/rules/# *Minibuf-1*#
+++ b/docs/content/docs/rules/# *Minibuf-1*#
@@ -1,1 +1,0 @@
-Directory ‘/home/mic/projects/registry-hunter/docs/content/rules/’ does not exist; create? (y or n) 


### PR DESCRIPTION
The macOS Profiles did not take into consideration Firefox Developer edition which uses the format qbtxwtsi.dev-edition-default rather than qbtxwtsi.default-release like the standard version. Adds Chromium (ungoogled-chromium), Google Chrome and Edge Beta, Canary and Dev support to macOS and Windows as well.

Additionally fixes some typos in the template and deletes the Minibuf files to allow cloning the repo on Windows (They don't seem very important but please correct me if this is wrong)