### PR TITLE
Fixes Firefox places download parsing on third party browsers

### DIFF
--- a/definitions/Firefox_Bookmarks.yaml
+++ b/definitions/Firefox_Bookmarks.yaml
@@ -65,7 +65,8 @@ Sources:
       dateAdded,
       lastModified
     FROM moz_annos
-    WHERE anno_attribute_id IN (1,2)
+    INNER JOIN moz_anno_attributes ON moz_annos.anno_attribute_id = moz_anno_attributes.id
+    WHERE moz_anno_attributes.name IN ('downloads/destinationFileURI','downloads/destinationFileName','downloads/metaData')
     ORDER BY moz_annos.dateAdded ASC
 
 - name: History


### PR DESCRIPTION
On several third party Firefox based browsers as well as older versions of Firefox the attribute ids 1 and 2 are not used for downloads. Other ids observed include 4,5,6 on Comodo IceDragon and 5,6,7 on Pale Moon. This switches to using the downloads/destinationFileURI, downloads/destinationFileName and downloads/metaData names instead no longer needing to be concerned about what ids are used. This has worked for all Firefox based browsers I have tested it on and I haven't noticed any regressions.