### PR TITLE
Fix Windows Browser Duplicates and remove Description from HistoryLegacy regex search

### DIFF
--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -6,21 +6,6 @@ Globs:
     - /home/*/{snap/brave/*/,}.config/BraveSoftware/Brave-Browser
   WindowsChromeProfiles:
     - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Vivaldi/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Chromium/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge/User Data
-    - C:\Users\*\AppData\{Roaming,Local}\Opera Software\Opera Stable\
-    - C:\Users\*\AppData\Local\Packages\TheBrowserCompany.Arc_*\LocalCache\Local\Arc\User Data
-    - C:\Users\*\AppData\{Roaming,Local}/EPISoftware/EpiBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/AVAST Software/Browser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/CentBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Comodo/{Chromodo,Dragon}/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/CryptoTab Browser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Shift/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Slimjet/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/WaveBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/YandexBrowser/User Data
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome*/User Data
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Google/Chrome*/User Data
@@ -34,8 +19,27 @@ Globs:
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Island/Island/User Data
     - C:\Users\*\AppData\{Roaming,Local}/Palo Alto Networks/PrismaAccessBrowser/User Data
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Palo Alto Networks/PrismaAccessBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Comodo/Dragon/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Comodo/Dragon/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Comodo/{Chromodo,Dragon}/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Comodo/{Chromodo,Dragon}/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Vivaldi/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Vivaldi/User Data
+    - C:\Users\*\AppData\Local\Packages\TheBrowserCompany.Arc_*\LocalCache\Local\Arc\User Data
+    - C:\Users\*\AppData\{Roaming,Local}/EPISoftware/EpiBrowser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/EPISoftware/EpiBrowser/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/AVAST Software/Browser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/AVAST Software/Browser/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/CentBrowser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/CentBrowser/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/CryptoTab Browser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/CryptoTab Browser/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Shift/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Shift/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Slimjet/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Slimjet/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/WaveBrowser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/WaveBrowser/User Data
+    - C:\Users\*\AppData\{Roaming,Local}/Yandex/YandexBrowser/User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Yandex/YandexBrowser/User Data
   MacOSChromeProfiles:
     - /Users/*/Library/Application Support/BraveSoftware/Brave*/
     - /Users/*/Library/Application Support/Google/Chrome*/
@@ -44,7 +48,6 @@ Globs:
     - /Users/*/Library/Application Support/PAB/Prisma Access Browser/
   WindowsFirefoxProfiles:
     - C:\Users\*\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\zen\Profiles
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles
     - C:\Users\*\AppData\{Roaming,Local}\librewolf\Profiles
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\librewolf\Profiles

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -5,84 +5,27 @@ Globs:
     - /home/*/.config/chromium
     - /home/*/{snap/brave/*/,}.config/BraveSoftware/Brave-Browser
   WindowsChromeProfiles:
-    - C:\Users\*\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/BraveSoftware/Brave*/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Google/Chrome*/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Google/Chrome*/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Chromium*/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Chromium*/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Microsoft/Edge*/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Microsoft/Edge*/User Data
-    - C:\Users\*\AppData\{Roaming,Local}\Opera Software\Opera Stable\
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Opera Software\Opera Stable\
-    - C:\Users\*\AppData\{Roaming,Local}/Island/Island/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Island/Island/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Palo Alto Networks/PrismaAccessBrowser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Palo Alto Networks/PrismaAccessBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Comodo/{Chromodo,Dragon}/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Comodo/{Chromodo,Dragon}/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Vivaldi/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Vivaldi/User Data
+    - C:\Users\*\AppData\{Roaming,Local}\*\*\User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\*\*\User Data
+    - C:\Users\*\AppData\{Roaming,Local}\*\User Data
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\*\User Data
+    - C:\Users\*\AppData\{Roaming,Local}\Opera Software\Opera*\
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Opera Software\Opera*\
     - C:\Users\*\AppData\Local\Packages\TheBrowserCompany.Arc_*\LocalCache\Local\Arc\User Data
-    - C:\Users\*\AppData\{Roaming,Local}/EPISoftware/EpiBrowser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/EPISoftware/EpiBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/AVAST Software/Browser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/AVAST Software/Browser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/CentBrowser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/CentBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/CryptoTab Browser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/CryptoTab Browser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Shift/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Shift/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Slimjet/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Slimjet/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/WaveBrowser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/WaveBrowser/User Data
-    - C:\Users\*\AppData\{Roaming,Local}/Yandex/YandexBrowser/User Data
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}/Yandex/YandexBrowser/User Data
   MacOSChromeProfiles:
-    - /Users/*/Library/Application Support/BraveSoftware/Brave*/
-    - /Users/*/Library/Application Support/Google/Chrome*/
-    - /Users/*/Library/Application Support/Microsoft Edge*/
-    - /Users/*/Library/Application Support/Chromium*/
-    - /Users/*/Library/Application Support/PAB/Prisma Access Browser/
+    - /Users/*/Library/Application Support/*/*/
+    - /Users/*/Library/Application Support/*/
   WindowsFirefoxProfiles:
-    - C:\Users\*\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Mozilla\Firefox\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\librewolf\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\librewolf\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Waterfox\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Waterfox\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\zen\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\zen\Profiles
+    - C:\Users\*\AppData\{Roaming,Local}\*\*\Profiles
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\*\*\Profiles
+    - C:\Users\*\AppData\{Roaming,Local}\*\Profiles
+    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\*\Profiles
     - C:\Users\*\Desktop\Tor Browser\Browser\TorBrowser\Data\Browser
-    - C:\Users\*\AppData\{Roaming,Local}\Mullvad\MullvadBrowser\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Mullvad\MullvadBrowser\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Floorp\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Floorp\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Moonchild Productions\Pale Moon\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Moonchild Productions\Pale Moon\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Moonchild Productions\Basilisk\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Moonchild Productions\Basilisk\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Basilisk-Dev\Basilisk\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Basilisk-Dev\Basilisk\Profiles
-    - C:\Users\*\AppData\{Roaming,Local}\Mozilla\SeaMonkey\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Mozilla\SeaMonkey\Profiles
     - C:\Users\*\AppData\{Roaming,Local}\K-Meleon
     - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\K-Meleon
-    - C:\Users\*\AppData\{Roaming,Local}\Comodo\IceDragon\Profiles
-    - C:\Windows\{System32,SysWOW64}\config\systemprofile\AppData\{Roaming,Local}\Comodo\IceDragon\Profiles
   LinuxFirefoxProfiles:
     - /home/*/.mozilla/firefox/*.default*
     - /home/*/snap/firefox/common/.mozilla/firefox/*.default*
   MacOSFirefoxProfiles:
-    - /Users/*/Library/Application Support/Firefox/Profiles
-    - /Users/*/Library/Application Support/librewolf/Profiles
-    - /Users/*/Library/Application Support/Waterfox/Profiles
-    - /Users/*/Library/Application Support/zen/Profiles
+    - /Users/*/Library/Application Support/*/Profiles
     - /Users/*/Library/Application Support/TorBrowser-Data/Browser
-    - /Users/*/Library/Application Support/MullvadBrowser/Profiles
-    - /Users/*/Library/Application Support/Floorp/Profiles
-    - /Users/*/Library/Application Support/Pale Moon/Profiles
-    - /Users/*/Library/Application Support/Basilisk/Profiles
-    - /Users/*/Library/Application Support/SeaMonkey/Profiles

--- a/definitions/Firefox_HistoryLegacy.yaml
+++ b/definitions/Firefox_HistoryLegacy.yaml
@@ -39,7 +39,7 @@ Sources:
        Frecency, OSPath
     FROM Rows
     WHERE VisitDate > DateAfter AND VisitDate < DateBefore
-      AND (Title, URL, Description) =~ FilterRegex
+      AND (Title, URL) =~ FilterRegex
 
   SQL: |
     SELECT


### PR DESCRIPTION
Fixes duplicate browser entries introduced by #45 including duplicate entries for Zen, Google Chrome, Chromium, Edge, Opera Stable and Comodo Dragon. Fixed the Browser path for Yandex Browser and added systemprofile support for them. Also fixes the VQL in Firefox_HistoryLegacy.yaml to remove the Description field from the Regex search which does not exist in the definition.