### PR TITLE
Add URL and Attribute Type to Firefox places downloads

### DIFF
--- a/definitions/Firefox_Bookmarks.yaml
+++ b/definitions/Firefox_Bookmarks.yaml
@@ -50,22 +50,29 @@ Sources:
     ORDER BY Bookmarks.id ASC
 
 - name: Downloads
+  Preamble: |
+    LET DownloadTypes <= dict(`downloads/destinationFileURI`='FileURI', `downloads/destinationFileName`='Filename', `downloads/metaData`='Metadata')
+
   VQL: |
-    SELECT PlaceID, Content,
+    SELECT PlaceID, URL, Content,
+       get(item= DownloadTypes, field=str(str=name), default="Unknown") AS Type,
        timestamp(epoch=dateAdded) AS DateAdded,
        timestamp(epoch=lastModified) AS LastModified,
        OSPath
     FROM Rows
     WHERE LastModified > DateAfter AND LastModified < DateBefore
-      AND Content =~ FilterRegex
+      AND (URL, Content) =~ FilterRegex
 
   SQL: |
     SELECT
       moz_annos.place_id AS PlaceID,
+      moz_places.url AS URL,
       moz_annos.content AS Content,
+      moz_anno_attributes.name,
       dateAdded,
       lastModified
     FROM moz_annos
     INNER JOIN moz_anno_attributes ON moz_annos.anno_attribute_id = moz_anno_attributes.id
+    INNER JOIN moz_places ON moz_places.id = moz_annos.place_id
     WHERE moz_anno_attributes.name IN ('downloads/destinationFileURI','downloads/destinationFileName','downloads/metaData')
     ORDER BY moz_annos.dateAdded ASC


### PR DESCRIPTION
This adds the URL field to the Firefox places download definition to save time having to cross-reference the database for the places id. It also adds an attribute type field to allow filtering out of field types if needed.